### PR TITLE
[20310] Feature: topic keys with non breaking ABI

### DIFF
--- a/rosidl_parser/rosidl_parser/definition.py
+++ b/rosidl_parser/rosidl_parser/definition.py
@@ -508,6 +508,15 @@ class Structure(Annotatable):
         self.namespaced_type = namespaced_type
         self.members = members or []
 
+    def has_any_member_with_annotation(self, name: str):
+        """
+        Returns whether any member has a particular annotation.
+
+        :param name: the annotation name
+        """
+        has_any = [member.name for member in self.members if member.has_annotation(name)]
+        return bool(has_any)
+
 
 class Include:
     """An include statement."""

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/identifier.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/identifier.h
@@ -26,6 +26,10 @@ extern "C"
 ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC
 extern const char * rosidl_typesupport_introspection_c__identifier;
 
+/// String identifying the typesupport introspection implementation in use.
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC
+extern const char * rosidl_typesupport_introspection_c__identifier_v2;
+
 #ifdef __cplusplus
 }
 #endif

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -39,6 +39,8 @@ typedef struct rosidl_typesupport_introspection_c__MessageMember_s
   /// If the type_id_ value is rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE,
   /// this points to an array describing the fields of the sub-interface.
   const rosidl_message_type_support_t * members_;
+  /// True if this field is a keyed field, false otherwise.
+  bool is_key_;
   /// True if this field is an array type, false if it is any other type. An
   /// array has the same value for / type_id_.
   bool is_array_;

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -96,8 +96,7 @@ typedef struct rosidl_typesupport_introspection_c__MessageMembers_s
   void (* init_function)(void *, enum rosidl_runtime_c__message_initialization);
   /// The function used to clean up the interface's in-memory representation
   void (* fini_function)(void *);
-  /// Array of the same size as the numebr of fields that indicates
-  /// whether a field is keyed or not
+  /// A pointer to the array that indicates whether each field is annotated as @key
   const bool * key_members_array_;
 } rosidl_typesupport_introspection_c__MessageMembers;
 

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -39,8 +39,6 @@ typedef struct rosidl_typesupport_introspection_c__MessageMember_s
   /// If the type_id_ value is rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE,
   /// this points to an array describing the fields of the sub-interface.
   const rosidl_message_type_support_t * members_;
-  /// True if this field is a keyed field, false otherwise.
-  bool is_key_;
   /// True if this field is an array type, false if it is any other type. An
   /// array has the same value for / type_id_.
   bool is_array_;
@@ -98,6 +96,9 @@ typedef struct rosidl_typesupport_introspection_c__MessageMembers_s
   void (* init_function)(void *, enum rosidl_runtime_c__message_initialization);
   /// The function used to clean up the interface's in-memory representation
   void (* fini_function)(void *);
+  /// Array of the same size as the numebr of fields that indicates
+  /// whether a field is keyed or not
+  const bool * key_members_array_;
 } rosidl_typesupport_introspection_c__MessageMembers;
 
 #endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_C__MESSAGE_INTROSPECTION_H_

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -238,6 +238,8 @@ for index, member in enumerate(message.structure.members):
         print('    0,  // upper bound of string')
         # const rosidl_message_type_support_t * members_
         print('    NULL,  // members of sub message (initialized later)')
+    # bool is_key_
+    print('    %s,  // is key' % ('true' if member.has_annotation('key') else 'false'))
     # bool is_array_
     print('    %s,  // is array' % ('true' if isinstance(member.type, AbstractNestedType) else 'false'))
     # size_t array_size_

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -201,6 +201,23 @@ bool @(function_prefix)__resize_function__@(message.structure.namespaced_type.na
 @[    end if]@
 @[  end if]@
 @[end for]@
+
+static bool @(function_prefix)__@(message.structure.namespaced_type.name)_key_members_array[@(len(message.structure.members))] = {
+@{
+for index, member in enumerate(message.structure.members):
+  if member.has_annotation('key'):
+    if index < len(message.structure.members) - 1:
+        print('  true,')
+    else:
+        print('  true')
+  else:
+    if index < len(message.structure.members) - 1:
+        print('  false,')
+    else:
+        print('  false')
+}@
+};
+
 static rosidl_typesupport_introspection_c__MessageMember @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array[@(len(message.structure.members))] = {
 @{
 for index, member in enumerate(message.structure.members):
@@ -238,8 +255,6 @@ for index, member in enumerate(message.structure.members):
         print('    0,  // upper bound of string')
         # const rosidl_message_type_support_t * members_
         print('    NULL,  // members of sub message (initialized later)')
-    # bool is_key_
-    print('    %s,  // is key' % ('true' if member.has_annotation('key') else 'false'))
     # bool is_array_
     print('    %s,  // is array' % ('true' if isinstance(member.type, AbstractNestedType) else 'false'))
     # size_t array_size_
@@ -280,7 +295,8 @@ static const rosidl_typesupport_introspection_c__MessageMembers @(function_prefi
   sizeof(@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),
   @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array,  // message members
   @(function_prefix)__@(message.structure.namespaced_type.name)_init_function,  // function to initialize message memory (memory has to be allocated)
-  @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function  // function to terminate message instance (will not free memory)
+  @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function,  // function to terminate message instance (will not free memory)
+  @(function_prefix)__@(message.structure.namespaced_type.name)_key_members_array // mapping to each field to know whether is keyed or not
 };
 
 // this is not const since it must be initialized on first access
@@ -310,7 +326,7 @@ if isinstance(type_, AbstractNestedType):
 @[end for]@
   if (!@(function_prefix)__@(message.structure.namespaced_type.name)_message_type_support_handle.typesupport_identifier) {
     @(function_prefix)__@(message.structure.namespaced_type.name)_message_type_support_handle.typesupport_identifier =
-      rosidl_typesupport_introspection_c__identifier;
+      rosidl_typesupport_introspection_c__identifier_v2;
   }
   return &@(function_prefix)__@(message.structure.namespaced_type.name)_message_type_support_handle;
 }

--- a/rosidl_typesupport_introspection_c/src/identifier.c
+++ b/rosidl_typesupport_introspection_c/src/identifier.c
@@ -15,3 +15,4 @@
 #include "rosidl_typesupport_introspection_c/identifier.h"
 
 const char * rosidl_typesupport_introspection_c__identifier = "rosidl_typesupport_introspection_c";
+const char * rosidl_typesupport_introspection_c__identifier_v2 = "rosidl_typesupport_introspection_c_v2";

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/identifier.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/identifier.hpp
@@ -24,6 +24,10 @@ namespace rosidl_typesupport_introspection_cpp
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_IMPORT
 extern const char * typesupport_identifier;
 
+/// String identifying the typesupport introspection implementation in use.
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_IMPORT
+extern const char * typesupport_identifier_v2;
+
 }  // namespace rosidl_typesupport_introspection_cpp
 
 #endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__IDENTIFIER_HPP_

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
@@ -103,8 +103,7 @@ typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMembers_s
   void (* init_function)(void *, rosidl_runtime_cpp::MessageInitialization);
   /// The function used to clean up the interface's in-memory representation
   void (* fini_function)(void *);
-  /// Array of the same size as the numebr of fields that indicates
-  /// whether a field is keyed or not
+  /// A pointer to the array that indicates whether each field is annotated as @key
   const bool * key_members_array_;
 } MessageMembers;
 

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
@@ -41,6 +41,8 @@ typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMember_s
   /// If the type_id_ value is rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE
   /// this points to an array describing the fields of the sub-interface.
   const rosidl_message_type_support_t * members_;
+  /// True if this field is a keyed field, false otherwise.
+  bool is_key_;
   /// True if this field is an array, false if it is a unary type. An array has the same value for
   /// type_id_.
   bool is_array_;

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
@@ -41,8 +41,6 @@ typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMember_s
   /// If the type_id_ value is rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE
   /// this points to an array describing the fields of the sub-interface.
   const rosidl_message_type_support_t * members_;
-  /// True if this field is a keyed field, false otherwise.
-  bool is_key_;
   /// True if this field is an array, false if it is a unary type. An array has the same value for
   /// type_id_.
   bool is_array_;
@@ -105,6 +103,9 @@ typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMembers_s
   void (* init_function)(void *, rosidl_runtime_cpp::MessageInitialization);
   /// The function used to clean up the interface's in-memory representation
   void (* fini_function)(void *);
+  /// Array of the same size as the numebr of fields that indicates
+  /// whether a field is keyed or not
+  const bool * key_members_array_;
 } MessageMembers;
 
 }  // namespace rosidl_typesupport_introspection_cpp

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -167,6 +167,23 @@ void resize_function__@(message.structure.namespaced_type.name)__@(member.name)(
 @[    end if]@
 @[  end if]@
 @[end for]@
+
+static const bool @(message.structure.namespaced_type.name)_key_members_array[@(len(message.structure.members))] = {
+@{
+for index, member in enumerate(message.structure.members):
+  if member.has_annotation('key'):
+    if index < len(message.structure.members) - 1:
+        print('  true,')
+    else:
+        print('  true')
+  else:
+    if index < len(message.structure.members) - 1:
+        print('  false,')
+    else:
+        print('  false')
+}@
+};
+
 static const ::rosidl_typesupport_introspection_cpp::MessageMember @(message.structure.namespaced_type.name)_message_member_array[@(len(message.structure.members))] = {
 @{
 for index, member in enumerate(message.structure.members):
@@ -204,8 +221,6 @@ for index, member in enumerate(message.structure.members):
         print('    0,  // upper bound of string')
         # const rosidl_message_type_support_t * members_
         print('    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<%s>(),  // members of sub message' % '::'.join(type_.namespaced_name()))
-    # bool is_key_
-    print('    %s,  // is key' % ('true' if member.has_annotation('key') else 'false'))
     # bool is_array_
     print('    %s,  // is array' % ('true' if isinstance(member.type, AbstractNestedType) else 'false'))
     # size_t array_size_
@@ -246,11 +261,12 @@ static const ::rosidl_typesupport_introspection_cpp::MessageMembers @(message.st
   sizeof(@('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),
   @(message.structure.namespaced_type.name)_message_member_array,  // message members
   @(message.structure.namespaced_type.name)_init_function,  // function to initialize message memory (memory has to be allocated)
-  @(message.structure.namespaced_type.name)_fini_function  // function to terminate message instance (will not free memory)
+  @(message.structure.namespaced_type.name)_fini_function,  // function to terminate message instance (will not free memory)
+  @(message.structure.namespaced_type.name)_key_members_array // mapping to each field to know whether is keyed or not
 };
 
 static const rosidl_message_type_support_t @(message.structure.namespaced_type.name)_message_type_support_handle = {
-  ::rosidl_typesupport_introspection_cpp::typesupport_identifier,
+  ::rosidl_typesupport_introspection_cpp::typesupport_identifier_v2,
   &@(message.structure.namespaced_type.name)_message_members,
   get_message_typesupport_handle_function,
   &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(GET_HASH_FUNC),

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -204,6 +204,8 @@ for index, member in enumerate(message.structure.members):
         print('    0,  // upper bound of string')
         # const rosidl_message_type_support_t * members_
         print('    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<%s>(),  // members of sub message' % '::'.join(type_.namespaced_name()))
+    # bool is_key_
+    print('    %s,  // is key' % ('true' if member.has_annotation('key') else 'false'))
     # bool is_array_
     print('    %s,  // is array' % ('true' if isinstance(member.type, AbstractNestedType) else 'false'))
     # size_t array_size_

--- a/rosidl_typesupport_introspection_cpp/src/identifier.cpp
+++ b/rosidl_typesupport_introspection_cpp/src/identifier.cpp
@@ -20,4 +20,8 @@ namespace rosidl_typesupport_introspection_cpp
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_EXPORT
 const char * typesupport_identifier = "rosidl_typesupport_introspection_cpp";
 
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_EXPORT
+const char * typesupport_identifier_v2 = "rosidl_typesupport_introspection_cpp_v2";
+
 }  // namespace rosidl_typesupport_introspection_cpp


### PR DESCRIPTION
This PR brings the changes in `rosidl` in order to support the topic keys feature without breaking ABI.

Note: This branch starts from the previous work from #1